### PR TITLE
fix: remove error prone ACARS hoppie check

### DIFF
--- a/hdw-common/src/systems/datalink/router/src/webinterfaces/AcarsConnector.ts
+++ b/hdw-common/src/systems/datalink/router/src/webinterfaces/AcarsConnector.ts
@@ -229,9 +229,6 @@ export class AcarsConnector {
     if (text.startsWith('ok') !== true) {
       return AtsuStatusCodes.ComFailed;
     }
-    if (text !== `ok {${station}}`) {
-      return AtsuStatusCodes.NoAtc;
-    }
 
     return AtsuStatusCodes.Ok;
   }


### PR DESCRIPTION
This check did falsely trigger on certain stations.

<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page