### PR TITLE
fix: correctly set store flightno in msfs2024

### DIFF
--- a/hdw-a339x/src/systems/instruments/src/MCDU/legacy_pages/atsu/A320_Neo_CDU_ATC_DepartReq.ts
+++ b/hdw-a339x/src/systems/instruments/src/MCDU/legacy_pages/atsu/A320_Neo_CDU_ATC_DepartReq.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2021-2023, 2025 FlyByWire Simulations
 // SPDX-License-Identifier: GPL-3.0
 
+import { isMsfs2024} from '@flybywiresim/fbw-sdk';
 import { AtsuStatusCodes, DclMessage } from '@datalink/common';
 import { CDU_SingleValueField } from '../../legacy/A320_Neo_CDU_Field';
 import { Keypad } from '../../legacy/A320_Neo_CDU_Keypad';
@@ -47,8 +48,12 @@ export class CDUAtcDepartReq {
     mcdu.page.Current = mcdu.page.ATCDepartReq;
 
     if (store.firstCall && store.callsign === '') {
-      if (mcdu.atsu.flightNumber().length !== 0) {
-        store.callsign = mcdu.atsu.flightNumber();
+      if(isMsfs2024()) {
+          store.callsign = mcdu.flightNumber;
+      } else {
+        if (mcdu.atsu.flightNumber().length !== 0) {
+          store.callsign = mcdu.atsu.flightNumber();
+        }
       }
     }
 


### PR DESCRIPTION
There was a bug in 2024 where the flightnumber would not be correctly set on the ATSU departure clerance page.

<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):

## Testing instructions
<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page