### PR TITLE
fix(a339x/sd): remove amber OIL QT indications

### DIFF
--- a/hdw-a339x/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
+++ b/hdw-a339x/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
@@ -243,24 +243,6 @@ const QuantityGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) 
           className={`NoFill ${displayedEngineOilQuantity === 0 && 'Hidden'} ${shouldQuantityPulse ? 'LinePulse' : 'GreenLine '}`}
           dashOffset={-40}
         />
-        <Needle
-          x={x}
-          y={y}
-          length={60}
-          scaleMax={100}
-          value={getNeedleValue(OIL_QTY_LOW_ADVISORY, OIL_QTY_MAX) - 3}
-          className="NoFill AmberHeavy"
-          dashOffset={-50}
-        />
-        <Needle
-          x={x}
-          y={y}
-          length={50}
-          scaleMax={100}
-          value={getNeedleValue(OIL_QTY_LOW_ADVISORY, OIL_QTY_MAX) - 2}
-          className="NoFill AmberLine"
-          dashOffset={-45}
-        />
         <text x={x + 5} y={y} className={`FontLarge TextCenter ${shouldQuantityPulse ? 'FillPulse' : 'FillGreen'}`}>
           <tspan className="FontLarge">{displayedEngineOilQuantity.toFixed(1).split('.')[0]}</tspan>
           <tspan className="FontSmall">.</tspan>


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
Removes the amber low oil qt indications from ENG SD page
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
Before:
![Screenshot 2025-05-12 095906](https://github.com/user-attachments/assets/d1293fe2-dbca-4625-9d92-50da957d3cb4)
After:
![Screenshot 2025-05-12 094459](https://github.com/user-attachments/assets/e9d0967e-8146-45b5-8fc8-2d3f9bf635c2)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
![Screenshot 2025-05-10 083802](https://github.com/user-attachments/assets/51c71f92-afcb-437a-bcc4-305fbe5f62b0)
I cannot find any A330neo references showing the amber indications 
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Load into aircraft on runway, switch to ENG SD page.
2. Observe no visible amber indications on OIL QT gauges

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page