### PR TITLE
fix(a339/sd): OIL QTY values

### DIFF
--- a/hdw-a339x/src/systems/instruments/src/SD/Pages/Crz/Crz.tsx
+++ b/hdw-a339x/src/systems/instruments/src/SD/Pages/Crz/Crz.tsx
@@ -72,8 +72,8 @@ export const OilComponent = () => {
   const [oilQuantLeft] = useSimVar('ENG OIL QUANTITY:1', 'percent', 1000);
   const [oilQuantRight] = useSimVar('ENG OIL QUANTITY:2', 'percent', 1000);
 
-  const oilLeft = splitDecimals(oilQuantLeft * 0.01 * 25);
-  const oilRight = splitDecimals(oilQuantRight * 0.01 * 25);
+  const oilLeft = splitDecimals(oilQuantLeft * 0.01 * 20);
+  const oilRight = splitDecimals(oilQuantRight * 0.01 * 20);
 
   const [leftVIBN1] = useSimVar('TURB ENG VIBRATION:1', 'Number', 1000);
   const [rightVIBN1] = useSimVar('TURB ENG VIBRATION:2', 'Number', 1000);

--- a/hdw-a339x/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
+++ b/hdw-a339x/src/systems/instruments/src/SD/Pages/Eng/Eng.tsx
@@ -204,8 +204,8 @@ const PressureGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) 
 
 const QuantityGauge = ({ x, y, engineNumber, fadecOn }: ComponentPositionProps) => {
   const [engineOilQuantity] = useSimVar(`ENG OIL QUANTITY:${engineNumber}`, 'percent', 100);
-  const OIL_QTY_MAX = 24.25;
-  const OIL_QTY_LOW_ADVISORY = 1.35;
+  const OIL_QTY_MAX = 20;
+  const OIL_QTY_LOW_ADVISORY = 1.5;
   const displayedEngineOilQuantity =
     engineOilQuantity === 100 ? OIL_QTY_MAX : Math.round(((engineOilQuantity / 100) * OIL_QTY_MAX) / 0.5) * 0.5; // Engine oil quantity has a step of 0.2
   const [quantityAtOrBelowLow, setQuantityAtOrBelowLow] = useState(false);


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #127 

## Summary of Changes
Fixes OIL QTY values on ENG and CRUSE SD pages to match A330neo references
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![Screenshot 2025-05-12 194835](https://github.com/user-attachments/assets/8f1ce2ff-7bbd-42bd-803c-33dfa89159d5)
![Screenshot 2025-05-12 195014](https://github.com/user-attachments/assets/495db62b-a0cf-4bc2-a9c7-88966b1dd281)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
FCOM
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Observe OIL QTY value on ENG SD page, confirm it reads 20.
2. Confirm 20 is also show on CRUISE SD page.

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page