### PR TITLE
fix(a339x/sd) Autobrake indicator position

### DIFF
--- a/hdw-a339x/src/systems/instruments/src/SD/Pages/Wheel/Wheel.tsx
+++ b/hdw-a339x/src/systems/instruments/src/SD/Pages/Wheel/Wheel.tsx
@@ -22,9 +22,16 @@ export const WheelPage = () => {
   const tempBrake7 = useArinc429Var('L:A32NX_REPORTED_BRAKE_TEMPERATURE_7', maxStaleness);
   const tempBrake8 = useArinc429Var('L:A32NX_REPORTED_BRAKE_TEMPERATURE_8', maxStaleness);
 
-  const roundedTemperatures = [tempBrake1, tempBrake2, tempBrake3, tempBrake4, tempBrake5, tempBrake6, tempBrake7, tempBrake8].map((temp) =>
-    temp.isNormalOperation() ? roundTemperature(temp.value) : null,
-  );
+  const roundedTemperatures = [
+    tempBrake1,
+    tempBrake2,
+    tempBrake3,
+    tempBrake4,
+    tempBrake5,
+    tempBrake6,
+    tempBrake7,
+    tempBrake8,
+  ].map((temp) => (temp.isNormalOperation() ? roundTemperature(temp.value) : null));
   const maxTemperature = roundedTemperatures
     .filter((temp) => temp !== null)
     .reduce((maxTemp, element) => Math.max(maxTemp, element), 0);
@@ -63,7 +70,7 @@ export const WheelPage = () => {
         <AlternateBraking x={276} y={433} />
       </HydraulicsProvider>
 
-      <AutoBrake x={318} y={570} />
+      <AutoBrake x={318} y={465} />
 
       <Gear
         x={40}


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes

- Adjusts position of autobrake indicator on WHEEL SD page.
- Other changes to code may have been due to prettier.

<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
![Screenshot 2025-05-14 175250](https://github.com/user-attachments/assets/fb549aac-2f51-4bc0-9885-9ecbe700fa10)

<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
![Screenshot 2025-05-14 173835](https://github.com/user-attachments/assets/bac894b1-8faf-4f09-82fa-f9b546a51086)

<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Ensure AUTO BRK indication position on WHEEL SD page matches reference.

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page