### PR TITLE
fix(a339x/hyd): change engine 1 reverser source to blue system

### DIFF
--- a/hdw-a339x/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
+++ b/hdw-a339x/src/wasm/systems/a320_systems/src/hydraulic/mod.rs
@@ -120,7 +120,6 @@ impl A330TiltingGearsFactory {
         let left_wing_gear = Self::new_a330_wing_gear(context, true);
         let right_wing_gear = Self::new_a330_wing_gear(context, false);
 
-
         A330TiltingGears::new(left_wing_gear, right_wing_gear)
     }
 }
@@ -2335,9 +2334,6 @@ impl A320Hydraulic {
 
         self.green_circuit
             .update_system_actuator_volumes(self.rudder_mechanical_assembly.green_actuator());
-
-        self.yellow_circuit
-            .update_system_actuator_volumes(self.reversers_assembly.green_actuator());
     }
 
     fn update_yellow_actuators_volume(&mut self) {
@@ -2414,6 +2410,9 @@ impl A320Hydraulic {
 
         self.blue_circuit
             .update_system_actuator_volumes(self.right_spoilers.actuator(2));
+
+        self.blue_circuit
+            .update_system_actuator_volumes(self.reversers_assembly.blue_actuator());
     }
 
     // All the core hydraulics updates that needs to be done at the slowest fixed step rate
@@ -2602,7 +2601,7 @@ impl A320Hydraulic {
         self.reversers_assembly.update(
             context,
             &self.engine_reverser_control,
-            self.green_circuit.system_section(),
+            self.blue_circuit.system_section(),
             self.yellow_circuit.system_section(),
         )
     }
@@ -6128,7 +6127,7 @@ impl A320Reversers {
         self.reversers[1].actuator()
     }
 
-    fn green_actuator(&mut self) -> &mut impl Actuator {
+    fn blue_actuator(&mut self) -> &mut impl Actuator {
         self.reversers[0].actuator()
     }
 }


### PR DESCRIPTION
<!-- Original Pull Request Template made by the fantastic FlyByWire Team for the A32NX <3 -->
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

<!-- Add the issues this PR fixes here. If no issues are related to this PR, then this line can be removed. -->
<!-- Add further issues with a full "Fixes #[issue_no]" line to ensure GitHub closes each one when the PR is merged. -->
Fixes #[issue_no]

## Summary of Changes
Changes the engine 1 reverser to be powered by the blue hydraulic system.
<!-- Please provide a summary of changes for this pull request, ensuring all changes are explained. -->

## Screenshots (if necessary)
<!-- If your PR includes visual changes, screenshots from before and after your change should always be included. -->
<!-- Please make your best efforts to provide useful before and after screenshots. They should match camera angle, zoom, size, time of day, etc. -->

## References
<!-- You should be making changes based on some kind of a reference (manuals, videos, IRL photos).  -->

## Additional context
<!-- Add any other context about the pull request here. -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jonny_23

## Testing instructions

1. Test that the reversers work normally.
2. Turn off the blue hydraulic pump and PTU.
3. Test the reversers again and check that ENG 1 reverser does not deploy (it may slightly open).
4. Turn blue pump back on but turn the yellow pump off.
5. Test the reversers again and check that ENG 2 reverser does not deploy (it may slightly open).

<!-- Detail how this PR should be tested by QA. Try to list important items that need checking, either directly changed by this PR or that could be affected by it -->

<!-- DO NOT DELETE THIS -->
## How to download the PR for Testing

Every new commit to this PR will cause a new A330-900neo artifact to be created, built, and uploaded.

1. Make sure you are signed in to GitHub
1. Click on the **Checks** tab on the PR
1. On the left side, click on the bottom **PR** tab
1. Click on the **HEADWIND-A339** download link at the bottom of the page